### PR TITLE
I4 publish command restored (#18)

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -16,21 +16,22 @@ pub const INDEX_COMMAND_NAME: &str = "index";
 pub const PUBLISH_COMMAND_NAME: &str = "publish";
 pub const HELP_COMMAND_NAME: &str = "help";
 
+/// Список ошибок
 #[derive(Error, Debug)]
 pub enum Error {
     // config
     #[error("Check parameter format, please. Should be --param-name or --param-name=value")]
     Parse(),
-    #[error("Value for {0} should not be empty")]
+    #[error("Value for {0} should be filled (not empty)")]
     EmptyValue(String),
-    #[error("Value for {0} are too long {1}")]
+    #[error("Value for {0} is too long. Expected less than {1}")]
     ValueTooLong(String, usize),
     #[error("Env variable error")]
     EnvVar(#[from] env::VarError),
     // deserializer
-    #[error("Have no clue about {0} key")]
+    #[error("Have no clue how process about {0} key")]
     UnknownKey(String),
-    #[error("Have no clue about {0} language value")]
+    #[error("Have no clue hpt to process {0} language value")]
     UnknownLang(String),
     #[error("Can't read file {0}")]
     ReadDraft(std::io::Error),

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -34,15 +34,18 @@ impl Command for Publish {
             return Ok(CommandResult { command, details });
         }
 
-        let (post_path, translation_path) = post.publish(
+        let published_post = post.publish(
             &self.config.get_posts_path_or_default(post.lang)?,
             &self.config.get_translation_path_or_default(post.lang)?,
         )?;
 
-        details.insert(String::from("post_path"), format!("{:?}", post_path));
+        details.insert(
+            String::from("post_path"),
+            format!("{:?}", published_post.path),
+        );
         details.insert(
             String::from("translation_path"),
-            format!("{:?}", translation_path),
+            format!("{:?}", published_post.translation_path),
         );
 
         Ok(CommandResult { command, details })

--- a/src/grow.rs
+++ b/src/grow.rs
@@ -21,7 +21,7 @@ const LF: char = '\n';
 
 const MAX_CHARS_IN_DESCRIPTION: usize = 255;
 const MAX_CHARS_IN_TITLE: usize = 75;
-const MAX_KEYWORDS_COUNT: usize = 75;
+const MAX_KEYWORDS_COUNT: usize = 10;
 
 // tests
 pub const TEST_POST_TITLE: &str = "Это тестовый заголовок";

--- a/src/grow/serdes.rs
+++ b/src/grow/serdes.rs
@@ -2,22 +2,27 @@
 use crate::command::Error;
 use crate::grow::post::Post;
 use std::collections::HashMap;
+use std::str::FromStr;
 
+use crate::grow::draft_post::DraftPost;
+use crate::grow::lang::Lang;
 use crate::grow::{
     ISO8601_DATE_TIME_FORMAT, KEYWORDS_DELIMITER, KEY_VALUE_DELIMITER, LF, META_DELIMITER,
 };
 
 ///
+/// Возвращает `DraftPost` на основе строки `draft_string`.
+///
+/// # Errors
 /// Преобразует строку в `DraftPost`. Строка должна удовлетворять формату grow записи. Например:
 /// key: value
 ///---
 /// content
 ///
-/// # Errors
-///
 /// Вернет Error при десериализации данных. Meta данные должны быть разделены `META_DELIMITER`, а meta
 /// ключ-значение разделены `KEY_VALUE_DELIMITER`.
-pub fn deserialize(draft_content: &str) -> Result<HashMap<&str, &str>, Error> {
+/// Доступные поля `title`, `description`,`keywords`, `lang`, `content`
+pub fn deserialize_to_draft_post(draft_content: &str) -> Result<DraftPost, Error> {
     let (meta, content) = draft_content
         .trim()
         .split_once(META_DELIMITER)
@@ -30,21 +35,28 @@ pub fn deserialize(draft_content: &str) -> Result<HashMap<&str, &str>, Error> {
 
     let meta_lines: Vec<&str> = meta.trim().split(LF).collect();
 
-    let mut hashmap = HashMap::new();
+    let mut draft_post = DraftPost::new();
 
     for line in meta_lines {
         let (key, value) = line.split_once(KEY_VALUE_DELIMITER).ok_or_else(|| {
             Error::IncorrectFormat(format!(
-                "Check meta key value delimiter should be {}",
+                "Meta key value should be delimited by {}",
                 KEY_VALUE_DELIMITER
             ))
         })?;
-        hashmap.insert(key, value);
+
+        match key {
+            "title" => draft_post.title(value)?,
+            "description" => draft_post.description(value)?,
+            "keywords" => draft_post.keywords_as_str(value, KEYWORDS_DELIMITER)?,
+            "lang" => draft_post.lang(Lang::from_str(value).map_err(Error::UnknownLang)?),
+            key => return Err(Error::UnknownKey(key.to_string())),
+        };
     }
 
-    hashmap.insert("content", content);
+    draft_post.content(content)?;
 
-    Ok(hashmap)
+    Ok(draft_post)
 }
 
 /// Преобразует Post в форматированную строку для grow записи.
@@ -72,7 +84,7 @@ pub fn serialize_with_template(post: &Post, template: String) -> String {
     process_template(template, key_values)
 }
 
-pub fn process_template<S: ::std::hash::BuildHasher>(
+pub fn process_template<S: std::hash::BuildHasher>(
     mut content: String,
     hashmap: HashMap<&str, String, S>,
 ) -> String {
@@ -85,7 +97,7 @@ pub fn process_template<S: ::std::hash::BuildHasher>(
 #[cfg(test)]
 mod tests {
     use crate::command::Error;
-    use crate::grow::serdes::deserialize;
+    use crate::grow::serdes::deserialize_to_draft_post;
     use crate::grow::{KEY_VALUE_DELIMITER, META_DELIMITER};
 
     #[test]
@@ -95,19 +107,24 @@ mod tests {
             META_DELIMITER
         ));
 
-        assert_eq!(err, deserialize("Incorrect value").err().unwrap());
+        assert_eq!(
+            err,
+            deserialize_to_draft_post("Incorrect value").err().unwrap()
+        );
     }
 
     #[test]
     fn fail_deserialize_when_meta_content_have_incorrect_key_value_delimiter() {
         let err = Error::IncorrectFormat(format!(
-            "Check meta key value delimiter should be {}",
+            "Meta key value should be delimited by {}",
             KEY_VALUE_DELIMITER
         ));
 
         assert_eq!(
             err,
-            deserialize("incorrect_meta_value---content").err().unwrap()
+            deserialize_to_draft_post("incorrect_meta_value---content")
+                .err()
+                .unwrap()
         );
     }
 }


### PR DESCRIPTION
* #I4-publish command Первая рабочая версия команды publish.
Работает публикация черновик-чистовик.
Работает dry-run.
Работает перевод.
Нужно ревью и фикс cargo test se of undeclared crate or module `mashinka` Добавил метод publish для Post. Инкаспулирует запись файлов grow(post + translation). Реализовал default() для DraftPost.
Заменили все panic! и unwrap на Result<*,*>.
Добавил зависимость thiserror, которая упрощает и уменьшает boilerplate для описания Error. Исправил все замечания clippy насчет unwrap/panic. Теперь в details Hashmap вместо String.
С подачи чата (thx PriamOlim) избавился от Box<dyn Type> в Result. Добавил дополнительные проверки в Config.
Исправил замечания от clippy to_owned -> clone.
impl FromStr for Lang вместо from_str (clippy).
Добавил пустые строки в translation.tpl шаблон (readability). Small fix PostPath -> TranslationPath.
Теперь все ошибки это enum Error, вместо Box<dyn Error>. Имправил тесты после изменения шаблона для translation. Удалил serdes файлы и перенс весь код в модуль serdes. Исправил замечания clippy.
Отключил must_use_candidate.
Исправил все замечания clippy.
Добавил MAX_KEYWORDS_COUNT = 10.
Отключил must_use_candidate.
module_name_repetitions для CommandResult.
Добавил тесты для serdes::deserialize.
Readme.
Исправления после review.

Co-authored-by: Radiopapus <viktor@zharina.info>